### PR TITLE
Minor Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ For Linux, the command-line for this is:
 ```shell
 cd QuantLib
 mkdir build
+cd build
 cmake .. -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release \
-  -DQL_EXTERNAL_SUBDIRECTORIES=`pwd`/../../xad;`pwd`/../../qlxad \
+  -DQL_EXTERNAL_SUBDIRECTORIES="`pwd`/../../xad;`pwd`/../../qlxad" \
   -DQL_EXTRA_LINK_LIBRARIES=qlxad \
   -DQL_NULL_AS_FUNCTIONS=ON \
   -DXAD_STATIC_MSVC_RUNTIME=ON


### PR DESCRIPTION
I needed to add quotes on linux to the external sub-directory setting, without them I only got the first directory (xad) and it just didn't build the qlxad test-suite, which might be hard to understand for someone just following the instructions.

Maybe it's just my shell, but double quotes (") fixed it.